### PR TITLE
Add test & improvements for file resolution with query

### DIFF
--- a/src/node-file-trace.ts
+++ b/src/node-file-trace.ts
@@ -283,9 +283,14 @@ export class Job {
   async readFile (path: string): Promise<string | Buffer | null> {
     const cached = this.fileCache.get(path);
     if (cached !== undefined) return cached;
+
+    const filePath = path.includes("?")
+      ? path.slice(0, path.indexOf("?"))
+      : path;
+
     await this.fileIOQueue.acquire();
     try {
-      const source = (await fsReadFile(path)).toString();
+      const source = (await fsReadFile(filePath)).toString();
       this.fileCache.set(path, source);
       return source;
     }

--- a/src/node-file-trace.ts
+++ b/src/node-file-trace.ts
@@ -241,36 +241,19 @@ export class Job {
       return;
     }
 
-    let queryString: string | null = null;
-    try {
-      // Store the querystring (including the leading `?`, in order to distinguish it from any
-      // similar values in the path itself) so that it can be restored if it gets stripped during
-      // resolution.
-      queryString = url.parse(dep).search;
-    } catch (e: any) {
-      this.warnings.add(new Error(`Failed to parse dependency ${dep} for querystring:\n${e && e.message}`));
-    }
-
     if (Array.isArray(resolved)) {
       for (const item of resolved) {
-        await this.emitResolved(item, queryString, path);
+        await this.emitResolved(item, path);
       }
     } else {
-      await this.emitResolved(resolved, queryString, path);
+      await this.emitResolved(resolved, path);
     }
   }
 
-  private emitResolved (resolvedPath: string, queryString: string | null, parent?: string): Promise<void> {
+  private emitResolved (resolvedPath: string, parent?: string): Promise<void> {
     // ignore builtins
     if (resolvedPath.startsWith('node:')) {
       return Promise.resolve();
-    }
-
-    // Dependencies which differ only by querystring are considered separate dependencies by
-    // webpack, and therefore need to be treated separately here, too. Resolution can strip
-    // the querystring off, in which case we need to put it back on to preserve the distinction.
-    if (queryString && !resolvedPath.endsWith(queryString)) {
-      resolvedPath += queryString
     }
 
     return this.emitDependency(resolvedPath, parent)

--- a/src/utils/get-file-for-import-path.ts
+++ b/src/utils/get-file-for-import-path.ts
@@ -1,0 +1,17 @@
+
+import { dirname, basename } from 'path';
+
+export function getReadableFilePath(path: string): { path: string, filePath: string, fileQuery: string} {
+    const dir = dirname(path);
+    const fullFile = basename(path);
+    const fileQuery = fullFile.includes('?') ? fullFile.slice(fullFile.indexOf('?')) : '';
+    const file = fullFile.includes('?') ? fullFile.slice(0, fullFile.indexOf('?')) : fullFile;
+
+    const filePath = dir === '.' ? file : `${dir}/${file}`;
+
+    return {
+        path,
+        filePath,
+        fileQuery
+    };
+}

--- a/test/unit/esm-query-follow/input.js
+++ b/test/unit/esm-query-follow/input.js
@@ -1,0 +1,4 @@
+import dep from './thing?aha';
+
+console.log(dep.hello);
+console.log(dep.thing);

--- a/test/unit/esm-query-follow/other-thing.js
+++ b/test/unit/esm-query-follow/other-thing.js
@@ -1,0 +1,1 @@
+export var hello = 'world';

--- a/test/unit/esm-query-follow/output.js
+++ b/test/unit/esm-query-follow/output.js
@@ -1,0 +1,6 @@
+[
+  "package.json",
+  "test/unit/esm-query-follow/input.js",
+  "test/unit/esm-query-follow/other-thing.js",
+  "test/unit/esm-query-follow/thing.js"
+]

--- a/test/unit/esm-query-follow/thing.js
+++ b/test/unit/esm-query-follow/thing.js
@@ -1,0 +1,4 @@
+import otherThing from './other-thing.js?aha';
+
+export var hello = otherThing.hello;
+export var thing = 'first';

--- a/test/unit/esm-query/input.js
+++ b/test/unit/esm-query/input.js
@@ -1,0 +1,5 @@
+import dep from './thing?aha';
+import dep2 from './thing';
+
+console.log(dep.hello);
+console.log(dep2.hello);

--- a/test/unit/esm-query/output.js
+++ b/test/unit/esm-query/output.js
@@ -1,6 +1,5 @@
 [
   "package.json",
   "test/unit/esm-query/input.js",
-  "test/unit/esm-query/thing.js",
-  "test/unit/esm-query/thing.js?aha"
+  "test/unit/esm-query/thing.js"
 ]

--- a/test/unit/esm-query/output.js
+++ b/test/unit/esm-query/output.js
@@ -1,0 +1,6 @@
+[
+  "package.json",
+  "test/unit/esm-query/input.js",
+  "test/unit/esm-query/thing.js",
+  "test/unit/esm-query/thing.js?aha"
+]

--- a/test/unit/esm-query/thing.js
+++ b/test/unit/esm-query/thing.js
@@ -1,0 +1,1 @@
+export var hello = 'world';


### PR DESCRIPTION
I took a stab at adding a test for the WIP improvements you started.

I needed to add a few further changes, as there have been places that have been tripped up by trying to load a file with the query part. 

I _think_ the test shows the expected behaviour quite nicely!

Basically, the idea is to always pass around the full paths, and only in places where we hit the filesystem strip the query out (but then still return the "full" path for further processing).

Actually, and I am not 100% sure, but I _think_ maybe the changes you made originally are not needed anymore then 🤔 I tried the test locally without your original code change, and the test also passed (as it would now handle the full paths incl. the query everywhere, hopefully). 