### PR TITLE
Add tests for query param imports

### DIFF
--- a/src/node-file-trace.ts
+++ b/src/node-file-trace.ts
@@ -266,16 +266,12 @@ export class Job {
       return;
     }
 
-    if (Array.isArray(resolved)) {
-      for (const item of resolved) {
-        // ignore builtins
-        if (item.startsWith('node:')) return;
-        await this.analyzeAndEmitDependency(item, path, cjsResolve);
-      }
-    } else {
+    // For simplicity, force `resolved` to be an array
+    resolved = Array.isArray(resolved) ? resolved : [resolved];
+    for (const item of resolved) {
       // ignore builtins
-      if (resolved.startsWith('node:')) return;
-      await this.analyzeAndEmitDependency(resolved, path, cjsResolve);
+      if (item.startsWith('node:')) return;
+      await this.analyzeAndEmitDependency(item, path, cjsResolve);
     }
   }
 

--- a/src/node-file-trace.ts
+++ b/src/node-file-trace.ts
@@ -248,12 +248,12 @@ export class Job {
     } catch (e1: any) {
       error = e1;
       try {
-        if (this.ts && dep.endsWith('.js') && e1 instanceof NotFoundError) {
+        if (this.ts && strippedDep.endsWith('.js') && e1 instanceof NotFoundError) {
           // TS with ESM relative import paths need full extensions
           // (we have to write import "./foo.js" instead of import "./foo")
           // See https://www.typescriptlang.org/docs/handbook/esm-node.html
-          const depTS = dep.slice(0, -3) + '.ts';
-          resolved = await this.resolve(depTS, path, this, cjsResolve);
+          const strippedDepTS = strippedDep.slice(0, -3) + '.ts';
+          resolved = await this.resolve(strippedDepTS + queryString, path, this, cjsResolve);
           error = undefined;
         }
       } catch (e2: any) {

--- a/src/node-file-trace.ts
+++ b/src/node-file-trace.ts
@@ -370,7 +370,11 @@ export class Job {
     return this.analyzeAndEmitDependency(path, parent)
   }
 
-  private async analyzeAndEmitDependency(path: string, parent?: string, cjsResolve?: boolean) {
+  private async analyzeAndEmitDependency(rawPath: string, parent?: string, cjsResolve?: boolean) {
+
+    // Strip the querystring, if any. (Only affects ESM dependencies.)
+    const { path } = parseSpecifier(rawPath, cjsResolve)
+
     if (this.processed.has(path)) {
       if (parent) {
         await this.emitFile(path, 'dependency', parent)

--- a/src/node-file-trace.ts
+++ b/src/node-file-trace.ts
@@ -408,8 +408,22 @@ export class Job {
       analyzeResult = cachedAnalysis;
     }
     else {
-      const source = await this.readFile(path);
-      if (source === null) throw new Error('File ' + path + ' does not exist.');
+      // By default, `this.readFile` is the regular `fs.readFile`, but a different implementation
+      // can be specified via a user option in the main `nodeFileTrace` entrypoint. Depending on
+      // that implementation, having a querystring on the end of the path may either a) be necessary
+      // in order to specify the right module from which to read, or b) lead to an `ENOENT: no such
+      // file or directory` error because it thinks the querystring is part of the filename. We
+      // therefore try it with the querystring first, but have the non-querystringed version as a
+      // fallback. (If there's no `?` in the given path, `maybeQuerystrigedPath` will equal `path`,
+      // so order is a moot point.)
+      const source = await this.readFile(rawPath) || await this.readFile(path) ;
+
+      if (source === null) {
+        const errorMessage = path === rawPath
+          ? 'File ' + path + ' does not exist.'
+          : 'Neither ' + path + ' nor ' + rawPath + ' exists.'
+        throw new Error(errorMessage);
+      }
       // analyze should not have any side-effects e.g. calling `job.emitFile` 
       // directly as this will not be included in the cachedAnalysis and won't
       // be emit for successive runs that leverage the cache

--- a/src/node-file-trace.ts
+++ b/src/node-file-trace.ts
@@ -239,6 +239,8 @@ export class Job {
   }
 
   private maybeEmitDep = async (dep: string, path: string, cjsResolve: boolean) => {
+    // Only affects ESM dependencies
+    const { path: strippedDep, queryString = '' } = parseSpecifier(dep, cjsResolve)
     let resolved: string | string[] = '';
     let error: Error | undefined;
     try {
@@ -446,8 +448,8 @@ export class Job {
         else
           await this.emitFile(asset, 'asset', path);
       }),
-      ...[...deps].map(async dep => this.maybeEmitDep(dep, path, !isESM)),
-      ...[...imports].map(async dep => this.maybeEmitDep(dep, path, false)),
+      ...[...deps].map(async dep => this.maybeEmitDep(dep, rawPath, !isESM)),
+      ...[...imports].map(async dep => this.maybeEmitDep(dep, rawPath, false)),
     ]);
   }
 }

--- a/src/node-file-trace.ts
+++ b/src/node-file-trace.ts
@@ -268,12 +268,12 @@ export class Job {
       for (const item of resolved) {
         // ignore builtins
         if (item.startsWith('node:')) return;
-        await this.emitDependency(item, path);
+        await this.analyzeAndEmitDependency(item, path, cjsResolve);
       }
     } else {
       // ignore builtins
       if (resolved.startsWith('node:')) return;
-      await this.emitDependency(resolved, path);
+      await this.analyzeAndEmitDependency(resolved, path, cjsResolve);
     }
   }
 
@@ -367,6 +367,10 @@ export class Job {
   }
 
   async emitDependency (path: string, parent?: string) {
+    return this.analyzeAndEmitDependency(path, parent)
+  }
+
+  private async analyzeAndEmitDependency(path: string, parent?: string, cjsResolve?: boolean) {
     if (this.processed.has(path)) {
       if (parent) {
         await this.emitFile(path, 'dependency', parent)
@@ -417,7 +421,7 @@ export class Job {
         const ext = extname(asset);
         if (ext === '.js' || ext === '.mjs' || ext === '.node' || ext === '' ||
             this.ts && (ext === '.ts' || ext === '.tsx') && asset.startsWith(this.base) && asset.slice(this.base.length).indexOf(sep + 'node_modules' + sep) === -1)
-          await this.emitDependency(asset, path);
+          await this.analyzeAndEmitDependency(asset, path, !isESM);
         else
           await this.emitFile(asset, 'asset', path);
       }),

--- a/src/node-file-trace.ts
+++ b/src/node-file-trace.ts
@@ -12,6 +12,30 @@ const fsReadFile = fs.promises.readFile;
 const fsReadlink = fs.promises.readlink;
 const fsStat = fs.promises.stat;
 
+type ParseSpecifierResult = {
+  path: string;
+  queryString: string | null
+}
+
+// Splits an ESM specifier into path and querystring (including the leading `?`). (If the specifier is CJS,
+// it is passed through untouched.)
+export function parseSpecifier(specifier: string, cjsResolve: boolean = true): ParseSpecifierResult {
+  let path = specifier;
+  let queryString = null;
+
+  if (!cjsResolve) {
+    // Regex which splits a specifier into path and querystring, inspired by that in `enhanced-resolve`
+    // https://github.com/webpack/enhanced-resolve/blob/157ed9bcc381857d979e56d2f20a5a17c6362bff/lib/util/identifier.js#L8
+    const match = /^(#?(?:\0.|[^?#\0])*)(\?(?:\0.|[^\0])*)?$/.exec(specifier);
+    if (match) {
+      path = match[1]
+      queryString = match[2]
+    }
+  }
+
+  return {path, queryString};
+}
+
 function inPath (path: string, parent: string) {
   const pathWithSep = join(parent, sep);
   return path.startsWith(pathWithSep) && path !== pathWithSep;

--- a/src/node-file-trace.ts
+++ b/src/node-file-trace.ts
@@ -268,9 +268,15 @@ export class Job {
 
     // For simplicity, force `resolved` to be an array
     resolved = Array.isArray(resolved) ? resolved : [resolved];
-    for (const item of resolved) {
+    for (let item of resolved) {
       // ignore builtins
       if (item.startsWith('node:')) return;
+
+      // If querystring was stripped during resolution, restore it
+      if (queryString && !item.endsWith(queryString)) {
+        item += queryString;
+      }
+      
       await this.analyzeAndEmitDependency(item, path, cjsResolve);
     }
   }

--- a/test/unit/esm-query-follow/input.js
+++ b/test/unit/esm-query-follow/input.js
@@ -1,0 +1,4 @@
+import dep from './thing?aha';
+
+console.log(dep.hello);
+console.log(dep.thing);

--- a/test/unit/esm-query-follow/other-thing.js
+++ b/test/unit/esm-query-follow/other-thing.js
@@ -1,0 +1,1 @@
+export var hello = 'world';

--- a/test/unit/esm-query-follow/output.js
+++ b/test/unit/esm-query-follow/output.js
@@ -1,0 +1,6 @@
+[
+  "package.json",
+  "test/unit/esm-query-follow/input.js",
+  "test/unit/esm-query-follow/other-thing.js",
+  "test/unit/esm-query-follow/thing.js"
+]

--- a/test/unit/esm-query-follow/thing.js
+++ b/test/unit/esm-query-follow/thing.js
@@ -1,0 +1,4 @@
+import otherThing from './other-thing.js?aha';
+
+export var hello = otherThing.hello;
+export var thing = 'first';

--- a/test/unit/esm-query/input.js
+++ b/test/unit/esm-query/input.js
@@ -1,0 +1,5 @@
+import dep from './thing?aha';
+import dep2 from './thing';
+
+console.log(dep.hello);
+console.log(dep2.hello);

--- a/test/unit/esm-query/output.js
+++ b/test/unit/esm-query/output.js
@@ -1,0 +1,5 @@
+[
+  "package.json",
+  "test/unit/esm-query/input.js",
+  "test/unit/esm-query/thing.js"
+]

--- a/test/unit/esm-query/thing.js
+++ b/test/unit/esm-query/thing.js
@@ -1,0 +1,1 @@
+export var hello = 'world';


### PR DESCRIPTION
Add tests for different query param scenarios.

Also add one that checks when different content is served for different query params.